### PR TITLE
Prevent search box being rendered when 'visible' is set to false

### DIFF
--- a/widgets/HorizontalMenu.php
+++ b/widgets/HorizontalMenu.php
@@ -177,6 +177,12 @@ class HorizontalMenu extends Menu {
         {
             throw new InvalidConfigException("The 'visible' option of search is required.");
         }
+        else
+        {
+            // do not render seacrh box if not visible
+            if ($this->search['visible'])
+                $data[] = Html::tag('li', $this->renderSearch());            
+        } 
         $data[] = Html::tag('li', $this->renderSearch());
         echo Html::tag($tag, implode("\n", $data), $options);
         echo Html::endTag('div');


### PR DESCRIPTION
When search box visibility is set to false, HorizontalMenu still render it, so I add some code to prevent search box being rendered when 'visible' is set to false.

Signed-off-by: Nur Hidayat hidayat365@gmail.com
